### PR TITLE
Add bot para aprovar PRs

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -4,6 +4,8 @@ autobuild
 aws
 bootcamp
 Cfg
+checkov
+CKV
 CLASSNAME
 claudioandre
 codeql

--- a/.github/workflows/approve-it.yml
+++ b/.github/workflows/approve-it.yml
@@ -1,0 +1,55 @@
+# ################################################################################
+#  Copyright (c) 2025  Claudio André <portfolio-2025br at claudioandre.slmail.me>
+#      ____              __                                _       _________  __
+#     / __ )____  ____  / /__________ _____ ___  ____     | |     / / ____/ |/ /
+#    / __  / __ \/ __ \/ __/ ___/ __ `/ __ `__ \/ __ \    | | /| / / __/  |   /
+#   / /_/ / /_/ / /_/ / /_/ /__/ /_/ / / / / / / /_/ /    | |/ |/ / /___ /   |
+#  /_____/\____/\____/\__/\___/\__,_/_/ /_/ /_/ .___/     |__/|__/_____//_/|_|
+#                                            /_/
+#
+# This program comes with ABSOLUTELY NO WARRANTY; express or implied.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, as expressed in version 2, seen at
+# https://www.gnu.org/licenses/gpl-2.0.html
+###############################################################################
+# GitHub Action to approve PRs
+# More info at https://github.com/portfolio-2025br/bootcamp-wex
+
+---
+name: Approve it
+
+"on":
+  workflow_dispatch:
+    #checkov:skip=CKV_GHA_7:This is automation, not a real build
+    inputs:
+      pullRequestNumber:
+        description: Pull request number
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  approve-pr:
+    runs-on: ubuntu-latest
+    name: approve-pr
+
+    permissions:
+      pull-requests: write
+
+    if: github.actor == 'portfolio-2025br'
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+
+      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+        with:
+          pull-request-number: ${{ github.event.inputs.pullRequestNumber }}
+          review-message: "Auto approved PR"


### PR DESCRIPTION
<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Descreva suas mudanças
<!-- prettier-ignore-end -->

Criar um bot que permita que se otimize a aprovação de PRs (com o auxilio de um humano que exerça o papel de aprovador). Isto ajuda os mantenedores a controlar e aprovar PRs (apesar de termos uma equipe com poucos membros).

- adicionar uma ferramenta para ajudar os mantenedores a controlar PRs que merecem mais atenção do que pode ser oferecido agora quando não temos equipe em quantidade adequada.

See: #8.

### Lista de verificação antes de solicitar uma revisão

- [x] Verifiquei que todos os fluxos de trabalho retornam com êxito.
- [x] Realizei uma auto-review do meu código.
- [ ] Adicionei testes que comprovam que minha correção é eficaz ou que meu recurso funciona.
- [x] Eu segui a [Conventional Commit spec][commitMessage].

### Tarefas do mantenedor

- [x] Rotular como: `bug`, `ci`, `docker`, `documentation`, `enhancement`.

[commitMessage]: https://www.conventionalcommits.org/en/v1.0.0/#summary
